### PR TITLE
refactor: include recommended movies in movie_detail requests

### DIFF
--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -1,34 +1,24 @@
 import { StackActions, useNavigation } from '@react-navigation/native'
 import { Skeleton } from '@rneui/themed'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { FlatList, StyleSheet, View } from 'react-native'
 import { Button, Text } from 'react-native-paper'
-import { Movies } from '../global/types'
+import { Movie } from '../global/types'
 import MovieCard from './MovieCard'
 import SectionLabel from './SectionLabel'
 
 interface MovieListProps {
   landscape?: boolean
   title: string
-  fetchFunc: () => Promise<Movies>
   onSeeMore: () => void
+  isLoading: boolean
+  data: Movie[]
+  seeMoreDisabled?: boolean
 }
 
 export default function MovieList(props: MovieListProps): React.ReactElement {
-  const [movies, setMovies] = useState<Movies>({} as Movies)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
   const navigation = useNavigation()
-  useEffect(() => {
-    props
-      .fetchFunc()
-      .then((data) => {
-        setMovies(data)
-        setIsLoading(false)
-      })
-      .catch((e) => {
-        console.error(e)
-      })
-  }, [])
+
   return (
     <View style={styles.container}>
       <View style={styles.listHeader}>
@@ -38,17 +28,17 @@ export default function MovieList(props: MovieListProps): React.ReactElement {
           textColor="#007AFF"
           contentStyle={styles.seeMore}
           onPress={props.onSeeMore}
-          disabled={!movies.results || movies.results.length === 0}
+          disabled={props.seeMoreDisabled}
           compact
         >
           See more
         </Button>
       </View>
-      {isLoading ? (
+      {props.isLoading ? (
         <Skeleton width="100%" height={200} animation="wave" />
       ) : (
         <FlatList
-          data={movies.results}
+          data={props.data}
           renderItem={({ item }) => (
             <MovieCard
               landscape={props.landscape}

--- a/src/global/types.ts
+++ b/src/global/types.ts
@@ -96,6 +96,7 @@ interface MovieDetail {
   vote_count: number
   release_dates: ReleaseDatesResponse // needed for certification
   casts: Casts
+  recommendations: Movies
 }
 
 interface MovieParams {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -17,12 +17,14 @@ async function fetchTMDB<T>(path: string, method = 'GET') {
   })
 }
 
-const fetchPopularMovies = async (page: number): Promise<Movies> => {
+const fetchPopularMovies = async (page = 1): Promise<Movies> => {
   return fetchTMDB(`/movie/popular?page=${page}`)
 }
 
 const fetchMovieDetail = async (movie_id: number): Promise<MovieDetail> => {
-  return fetchTMDB(`/movie/${movie_id}?append_to_response=release_dates,casts`)
+  return fetchTMDB(
+    `/movie/${movie_id}?append_to_response=release_dates,casts,recommendations`,
+  )
 }
 
 const fetchAvailableMovieGenres = async (): Promise<Genres> => {
@@ -48,15 +50,15 @@ const fetchMoviesByTitle = async (title: string): Promise<Movies> => {
   )
 }
 
-const fetchNowPlayingMovies = async (page: number): Promise<Movies> => {
+const fetchNowPlayingMovies = async (page = 1): Promise<Movies> => {
   return fetchTMDB(`/movie/now_playing?page=${page}`)
 }
 
-const fetchTopRatedMovies = async (page: number): Promise<Movies> => {
+const fetchTopRatedMovies = async (page = 1): Promise<Movies> => {
   return fetchTMDB(`/movie/top_rated?page=${page}`)
 }
 
-const fetchUpcomingMovies = async (page: number): Promise<Movies> => {
+const fetchUpcomingMovies = async (page = 1): Promise<Movies> => {
   return fetchTMDB(`/movie/upcoming?page=${page}`)
 }
 

--- a/src/screens/AllMovies.tsx
+++ b/src/screens/AllMovies.tsx
@@ -63,7 +63,7 @@ export default function AllMovies({
       estimatedItemSize={175}
       onEndReachedThreshold={0.3}
       ListFooterComponent={() => {
-        if (isFetching) {
+        if (isFetching && data && data.pages.length > 0) {
           return <ActivityIndicator size="large" color="#3495ff" animating />
         }
       }}

--- a/src/screens/Detail.tsx
+++ b/src/screens/Detail.tsx
@@ -14,7 +14,7 @@ import MovieList from '../components/MovieList'
 import PressableAvatar from '../components/PressableAvatar'
 import SectionLabel from '../components/SectionLabel'
 import { MovieDetail } from '../global/types'
-import { fetchMovieDetail, fetchRecommendedMovies } from '../lib/fetch'
+import { fetchMovieDetail } from '../lib/fetch'
 
 interface DetailProps {
   id: number
@@ -107,7 +107,12 @@ export default function Detail({
   return (
     <View style={styles.container}>
       {isLoading ? (
-        <ActivityIndicator size="large" />
+        <ActivityIndicator
+          size="large"
+          style={{
+            marginTop: 15,
+          }}
+        />
       ) : (
         <ScrollView>
           <MovieBanner
@@ -254,7 +259,9 @@ export default function Detail({
           </View>
           <MovieList
             title="You might also like"
-            fetchFunc={async () => fetchRecommendedMovies(movie.id)}
+            data={movie.recommendations.results}
+            isLoading={isLoading}
+            seeMoreDisabled={!movie || movie.recommendations.total_pages <= 1}
             onSeeMore={() => {
               navigation.dispatch(
                 StackActions.push('AllMovies', {

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,8 +1,9 @@
 import { StackActions, useNavigation } from '@react-navigation/native'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { ScrollView } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import MovieList from '../components/MovieList'
+import { Movies } from '../global/types'
 import {
   fetchNowPlayingMovies,
   fetchPopularMovies,
@@ -10,7 +11,63 @@ import {
   fetchUpcomingMovies,
 } from '../lib/fetch'
 
+interface MoviesData {
+  data: Movies
+  isLoading: boolean
+}
+
 export default function Home(): React.ReactElement {
+  const [nowPlayingMovies, setNowPlayingMovies] = useState<MoviesData>({
+    data: {} as Movies,
+    isLoading: true,
+  })
+  const [upcomingMovies, setUpcomingMovies] = useState<MoviesData>({
+    data: {} as Movies,
+    isLoading: true,
+  })
+  const [topRatedMovies, setTopRatedMovies] = useState<MoviesData>({
+    data: {} as Movies,
+    isLoading: true,
+  })
+  const [popularMovies, setPopularMovies] = useState<MoviesData>({
+    data: {} as Movies,
+    isLoading: true,
+  })
+
+  useEffect(() => {
+    fetchNowPlayingMovies()
+      .then((data) => {
+        setNowPlayingMovies({ data, isLoading: false })
+      })
+      .catch((e) => {
+        console.error(e)
+      })
+
+    fetchUpcomingMovies()
+      .then((data) => {
+        setUpcomingMovies({ data, isLoading: false })
+      })
+      .catch((e) => {
+        console.error(e)
+      })
+
+    fetchTopRatedMovies()
+      .then((data) => {
+        setTopRatedMovies({ data, isLoading: false })
+      })
+      .catch((e) => {
+        console.error(e)
+      })
+
+    fetchPopularMovies()
+      .then((data) => {
+        setPopularMovies({ data, isLoading: false })
+      })
+      .catch((e) => {
+        console.error(e)
+      })
+  }, [])
+
   const navigation = useNavigation()
 
   return (
@@ -18,7 +75,11 @@ export default function Home(): React.ReactElement {
       <ScrollView>
         <MovieList
           title="Currently In Theaters"
-          fetchFunc={async () => fetchNowPlayingMovies(1)}
+          data={nowPlayingMovies.data.results}
+          isLoading={nowPlayingMovies.isLoading}
+          seeMoreDisabled={
+            !nowPlayingMovies.data || nowPlayingMovies.data.total_pages <= 1
+          }
           onSeeMore={() => {
             navigation.dispatch(
               StackActions.push('AllMovies', {
@@ -31,7 +92,11 @@ export default function Home(): React.ReactElement {
         />
         <MovieList
           title="Upcoming Movies"
-          fetchFunc={async () => fetchUpcomingMovies(1)}
+          data={upcomingMovies.data.results}
+          isLoading={upcomingMovies.isLoading}
+          seeMoreDisabled={
+            !upcomingMovies.data || upcomingMovies.data.total_pages <= 1
+          }
           onSeeMore={() => {
             navigation.dispatch(
               StackActions.push('AllMovies', {
@@ -43,7 +108,11 @@ export default function Home(): React.ReactElement {
         />
         <MovieList
           title="Top Rated Movies"
-          fetchFunc={async () => fetchTopRatedMovies(1)}
+          data={topRatedMovies.data.results}
+          isLoading={topRatedMovies.isLoading}
+          seeMoreDisabled={
+            !topRatedMovies.data || topRatedMovies.data.total_pages <= 1
+          }
           onSeeMore={() => {
             navigation.dispatch(
               StackActions.push('AllMovies', {
@@ -55,7 +124,11 @@ export default function Home(): React.ReactElement {
         />
         <MovieList
           title="Popular Movies"
-          fetchFunc={async () => fetchPopularMovies(1)}
+          data={popularMovies.data.results}
+          isLoading={popularMovies.isLoading}
+          seeMoreDisabled={
+            !popularMovies.data || popularMovies.data.total_pages <= 1
+          }
           onSeeMore={() => {
             navigation.dispatch(
               StackActions.push('AllMovies', {


### PR DESCRIPTION
now when users open detail screen, it only performs 1 http request (prev it was 2)